### PR TITLE
[bitnami/kube-state-metrics] fix if to check  .Values.namespaces

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -23,4 +23,4 @@ name: kube-state-metrics
 sources:
   - https://github.com/bitnami/bitnami-docker-kube-state-metrics
   - https://github.com/kubernetes/kube-state-metrics
-version: 2.1.10
+version: 2.1.11

--- a/bitnami/kube-state-metrics/templates/deployment.yaml
+++ b/bitnami/kube-state-metrics/templates/deployment.yaml
@@ -152,7 +152,7 @@ spec:
             {{- if .Values.kubeResources.volumeattachments }}
             - --resources=volumeattachments
             {{- end }}
-            {{- if .Values.namespace }}
+            {{- if .Values.namespaces }}
             - --namespaces={{ .Values.namespaces }}
             {{- end }}
             {{- range $key, $value := .Values.extraArgs }}


### PR DESCRIPTION
**Description of the change**

fix if to check  .Values.namespaces instead of  .Values.namespace in deployment.yml

**Benefits**

Correct namespace selection for running pod

**Possible drawbacks**

none


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
